### PR TITLE
Add loaded ItemSpawnerIDs to SpawnerIDDic, allowing for custom guns in the Vault

### DIFF
--- a/H3VR.Sideloader/AssetLoaders/FVRObjectLoader.cs
+++ b/H3VR.Sideloader/AssetLoaders/FVRObjectLoader.cs
@@ -64,13 +64,15 @@ namespace H3VR.Sideloader.AssetLoaders
 
         [HarmonyPatch(typeof(IM), "GenerateItemDBs")]
         [HarmonyPostfix]
-        private static void InjectObjects(IM __instance)
+        private static void InjectObjects(IM __instance, Dictionary<string, ItemSpawnerID> ___SpawnerIDDic)
         {
             var im = __instance;
             foreach (var itemSpawnerId in ItemSpawnerIds)
             {
                 IM.CD[itemSpawnerId.Category].Add(itemSpawnerId);
                 IM.SCD[itemSpawnerId.SubCategory].Add(itemSpawnerId);
+                if (!___SpawnerIDDic.ContainsKey(itemSpawnerId.ItemID))
+                    ___SpawnerIDDic[itemSpawnerId.ItemID] = itemSpawnerId;
             }
 
             foreach (var fvrObject in Objects)


### PR DESCRIPTION
I forgot to add loaded ItemSpawnerIDs to this dictionary. Now, loaded ids will get added to IM.SpawnerIDDic, which allows IM.GetSpawnerID to return injected ids. The Vault uses this function for its serialization, so now the Vault will work on modded guns as intended. This also lets the Wrist Menu pick up on the held object's ItemSpawnerID display name, though that's minor in comparison.